### PR TITLE
fix(ci): Avoid upgrading AKS clusters to preview versions or same ver…

### DIFF
--- a/.github/workflows/update-aks.yml
+++ b/.github/workflows/update-aks.yml
@@ -30,12 +30,30 @@ jobs:
             IFS=':' read -ra PARTS <<< "$entry"
             RG="${PARTS[0]}"
             CLUSTER="${PARTS[1]}"
+            TARGET_K8S_VERSION=""
+
             if [ -z "$AKS_VERSION" ]; then
-              VERSION=$(az aks get-upgrades --resource-group "$RG" --name "$CLUSTER" --query 'controlPlaneProfile.upgrades[-1].kubernetesVersion' -o tsv)
+              echo "No specific version provided for $CLUSTER, querying for latest available non-preview upgrade..."
+              LATEST_UPGRADE_VERSION=$(az aks get-upgrades --resource-group "$RG" --name "$CLUSTER" --query "controlPlaneProfile.upgrades[?isPreview==null].kubernetesVersion | sort(@) | [-1]" -o tsv)
+
+              if [ -z "$LATEST_UPGRADE_VERSION" ] || [ "$LATEST_UPGRADE_VERSION" = "null" ]; then
+                echo "No available non-preview upgrades found for $CLUSTER. Skipping."
+                continue
+              else
+                echo "Latest available non-preview upgrade version for $CLUSTER: $LATEST_UPGRADE_VERSION"
+                TARGET_K8S_VERSION="$LATEST_UPGRADE_VERSION"
+              fi
             else
-              VERSION="$AKS_VERSION"
+              echo "Specific version provided for all clusters: $AKS_VERSION"
+              TARGET_K8S_VERSION="$AKS_VERSION"
             fi
-            echo "Upgrading $CLUSTER in $RG to version $VERSION"
-            az aks upgrade --resource-group "$RG" --name "$CLUSTER" --kubernetes-version "$VERSION" --yes
+
+            CURRENT_VERSION=$(az aks show --resource-group "$RG" --name "$CLUSTER" --query "kubernetesVersion" -o tsv)
+            if [ "$TARGET_K8S_VERSION" = "$CURRENT_VERSION" ]; then
+              echo "Cluster $CLUSTER is already at the target version $TARGET_K8S_VERSION. No upgrade needed."
+            else
+              echo "Attempting to upgrade $CLUSTER in $RG to version $TARGET_K8S_VERSION"
+              az aks upgrade --resource-group "$RG" --name "$CLUSTER" --kubernetes-version "$TARGET_K8S_VERSION" --yes
+            fi
           done
         shell: bash


### PR DESCRIPTION
…sion

The `update-aks.yml` workflow was using a query that selected the latest version from the `az aks get-upgrades` list, which could include preview versions. This is inconsistent with the `update-single-aks.yml` workflow, which explicitly selects the latest stable version.

This commit modifies the `update-aks.yml` workflow to:
1. Query for the latest non-preview (stable) AKS version.
2. Check if the cluster is already at the target version before attempting an upgrade.
3. Skip clusters for which no non-preview upgrade is available.

This makes the batch update workflow more robust and consistent with the single update workflow.

A new automated test was not added because it would require a live Azure environment and credentials, which are not available in the testing environment. The fix was verified by manual code review.